### PR TITLE
Added undocumented fields, several helper functions

### DIFF
--- a/src/awardwallet/model.py
+++ b/src/awardwallet/model.py
@@ -144,7 +144,7 @@ class SubAccount(BaseModel):
     balance: str
     balance_raw: Optional[float] = None
     last_detected_change: Optional[str] = None
-    expiration_date: Optional[datetime] = None    
+    expiration_date: Optional[datetime] = None
     properties: Optional[list[AccountProperty]] = []
     history: Optional[list[HistoryItem]] = []
 

--- a/src/awardwallet/model.py
+++ b/src/awardwallet/model.py
@@ -25,6 +25,30 @@ class AccessLevel(IntEnum):
     FULL_CONTROL = 3
 
 
+class AccountPropertyKind(IntEnum):
+    """Type of AccountProperty"""
+
+    ACCOUNT_NUMBER = 1
+    EXPIRATION = 2
+    STATUS = 3
+    LIFETIME_POINTS = 4
+    MEMBER_SINCE = 5
+    EXPIRING_BALANCE = 6
+    YTD_MILES = 7
+    YTD_SEGMENTS = 8
+    NEXT_ELITE_LEVEL = 9
+    MILES_NEEDED_TO_NEXT_LEVEL = 10
+    SEGMENTS_NEEDED_TO_NEXT_LEVEL = 11
+    NAME = 12
+    LAST_ACTIVITY = 13
+    MILES_NEEDED_FOR_NEXT_REWARD = 14
+    STATUS_EXPIRATION = 15
+    MILES_TO_RETAIN_STATUS = 16
+    SEGMENTS_TO_RETAIN_STATUS = 17
+    ALLIANCE_ELITE_LEVEL = 18
+    STATUS_MILES = 19
+
+
 class AccountProperty(BaseModel):
     """A secondary attribute of a loyalty account."""
 
@@ -33,7 +57,7 @@ class AccountProperty(BaseModel):
     name: str
     value: str
     rank: Optional[int] = None
-    kind: Optional[int] = None
+    kind: Optional[AccountPropertyKind] = None
     is_value_verified: Optional[bool] = None
 
 
@@ -152,6 +176,20 @@ class Account(BaseModel):
     history: Optional[list[HistoryItem]] = []
     sub_accounts: Optional[list[SubAccount]] = []
 
+    def get_account_number(self) -> str:
+        """Helper method to extract the account number from properties."""
+        for prop in self.properties or []:
+            if prop.kind == AccountPropertyKind.ACCOUNT_NUMBER:
+                return prop.value
+        return self.login or ""
+
+    def get_account_property(self, kind: AccountPropertyKind) -> Optional[str]:
+        """Helper method to extract a specific property value by its kind."""
+        for prop in self.properties or []:
+            if prop.kind == kind:
+                return prop.value
+        return None
+
 
 class AccountsIndexItem(BaseModel):
     """A lightweight reference to an account, used in list views."""
@@ -256,6 +294,24 @@ class ProviderKind(IntEnum):
     SURVEY = 9
     CRUISE = 10
     PARKING = 12
+
+    @classmethod
+    def from_str(cls, value: str) -> ProviderKind | None:
+        """Convert an Account 'kind' string to a ProviderKind enum."""
+        mapping = {
+            "Airlines": cls.AIRLINE,
+            "Hotels": cls.HOTEL,
+            "Rentals": cls.CAR_RENTAL,
+            "Trains": cls.TRAIN,
+            "Other": cls.OTHER,
+            "Credit Cards": cls.CREDIT_CARD,
+            "Shopping": cls.SHOPPING,
+            "Dining": cls.DINING,
+            "Surveys": cls.SURVEY,
+            "Cruises": cls.CRUISE,
+            "Parking": cls.PARKING,
+        }
+        return mapping.get(value)
 
 
 class ProviderInfo(BaseModel):

--- a/src/awardwallet/model.py
+++ b/src/awardwallet/model.py
@@ -34,6 +34,7 @@ class AccountProperty(BaseModel):
     value: str
     rank: Optional[int] = None
     kind: Optional[int] = None
+    is_value_verified: Optional[bool] = None
 
 
 class TypedHistoryValue(BaseModel):
@@ -138,9 +139,11 @@ class Account(BaseModel):
     edit_url: str
     balance: str
     balance_raw: float
+    is_balance_verified: Optional[bool] = None
     owner: str
     error_code: int
     last_detected_change: Optional[str] = None
+    barcode: Optional[str] = None
     expiration_date: Optional[datetime] = None
     last_retrieve_date: Optional[datetime] = None
     last_change_date: Optional[datetime] = None

--- a/src/awardwallet/model.py
+++ b/src/awardwallet/model.py
@@ -144,6 +144,7 @@ class SubAccount(BaseModel):
     balance: str
     balance_raw: Optional[float] = None
     last_detected_change: Optional[str] = None
+    expiration_date: Optional[datetime] = None    
     properties: Optional[list[AccountProperty]] = []
     history: Optional[list[HistoryItem]] = []
 

--- a/tests/data/account_details.json
+++ b/tests/data/account_details.json
@@ -10,9 +10,11 @@
     "editUrl": "https://business.awardwallet.com/account/edit/7654321",
     "balance": "146,780",
     "balanceRaw": 146780,
+    "isBalanceVerified": true,
     "owner": "John Smith",
     "errorCode": 1,
     "lastDetectedChange": "+750",
+    "barcode": "code128",
     "expirationDate": "2018-12-10T00:00:00+00:00",
     "lastRetrieveDate": "2016-01-15T00:00:00+00:00",
     "lastChangeDate": "2016-01-15T00:49:33+00:00",
@@ -57,7 +59,8 @@
         "name": "Level",
         "value": "Blue",
         "rank": 0,
-        "kind": 3
+        "kind": 3,
+        "isValueVerified": true
       },
       {
         "name": "Membership no",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ from awardwallet.client import (
 )
 from awardwallet.model import (
     AccessLevel,
+    AccountPropertyKind,
     ConnectedUserListItem,
     GetAccountDetailsResponse,
     GetConnectedUserDetailsResponse,
@@ -146,6 +147,12 @@ class TestGetDetailsMethods:
         # Assert
         assert isinstance(details, GetAccountDetailsResponse)
         assert details.account.account_id == account_id
+        assert details.account.get_account_number() == "1122334455"
+        assert (
+            details.account.get_account_property(AccountPropertyKind.LAST_ACTIVITY)
+            == "10-Dec-15"
+        )
+        assert ProviderKind.from_str(details.account.kind) == ProviderKind.AIRLINE
 
     @pytest.mark.parametrize(
         "test_data", ["tests/data/user_details.json"], indirect=True


### PR DESCRIPTION
1. I added several fields that are not documented but returned by the AwardWallet API to their respective classes.

2. I also added some quality-of-life helpers:

- A new `IntEnum` for account property kinds.
- `get_account_number` that follows the apparent logic of the AwardWallet site.
- `get_account_property` to easily access specific properties (based on their kind).
- A `string` to `ProviderKind` converter.

3. Lastly, I added a handful of tests to cover the new helpers, and all tests are passing.